### PR TITLE
Install elm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
         "reactor": "elm reactor",
         "build": "cp src/{index.js,fonts.json,styles.css,index.html} dist && cp assets/* dist && elm make src/Cli.elm --output=dist/cli.js && elm make src/Main.elm --output=dist/main.js",
         "start": "npm run build && node dist/index.js"
+    },
+    "dependencies": {
+        "elm": "^0.19.1-3"
     }
 }


### PR DESCRIPTION
To avoid asking maintainers to install Elm manually, we can install it via npm. This reduces the friction for JS developers