### PR TITLE
Web (CSS) Downloads

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -8,13 +8,13 @@
         "direct": {
             "elm/browser": "1.0.2",
             "elm/core": "1.0.4",
+            "elm/file": "1.0.5",
             "elm/html": "1.0.0",
             "elm/http": "2.0.0",
             "elm/json": "1.1.3"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/file": "1.0.5",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2"

--- a/src/styles.css
+++ b/src/styles.css
@@ -154,10 +154,12 @@ body {
   display: flex;
   flex-direction: column;
   color: #121212;
+
+  --brand-400: #052962;
 }
 
 .main__header {
-  background-color: #052962;
+  background-color: var(--brand-400);
   font-family: "Guardian Titlepiece";
   color: #fff;
   text-align: right;
@@ -172,7 +174,7 @@ body {
   margin: 0;
 }
 
-.fields__keyline {
+.fields__keyline, .font-faces__keyline {
   background-image: repeating-linear-gradient(#DCDCDC, #DCDCDC 1px, transparent 1px, transparent 4px);
   width: 100%;
   height: 16px;
@@ -191,33 +193,35 @@ body {
   border-right: 1px solid #dcdcdc;
 }
 
-.fields__heading {
+.fields__heading, .font-faces__heading {
   margin: 0;
   font-family: "Guardian Headline";
   font-weight: bold;
 }
 
-.fields__button {
-  margin: 1rem 0.5rem 1rem 0;
-  border-radius: 100px;
-  background-color: #052962;
-  font-size: 1rem;
-  font-family: "Guardian Text Sans";
-  font-weight: bold;
+.fields__button, .font-faces__download {
+  border-radius: 2rem;
+  background-color: var(--brand-400);
   color: #fff;
   border: none;
-  padding: 0.5rem 1rem;
+  padding: 0 1.5rem;
+  font-size: 1.025rem;
+  height: 2.75rem;
   cursor: pointer;
+  font-family: "Guardian Text Sans";
+  font-weight: bold;
+  margin: 0.5rem 0.5rem 1.5rem 0;
 }
 
 .fields__button--secondary {
   background-color: #C1D8FC;
-  color: #052962;
+  color: var(--brand-400);
 }
 
 .fields__font-list {
   list-style: none;
   padding: 0;
+  margin-top: 0;
 }
 
 .fields__font {
@@ -237,13 +241,12 @@ body {
 
 .font-faces {
   white-space: pre-wrap;
-  padding: 3rem 1rem 1rem 3rem;
+  padding: 1rem 1rem 3rem;
   flex: 1;
 }
 
-.font-faces__heading {
-  font-family: "Guardian Headline";
-  font-size: large;
-  font-weight: bold;
+.font-faces__source {
   cursor: pointer;
+  font-family: "Guardian Text Egyptian";
+  margin: 0.5rem 0;
 }


### PR DESCRIPTION
## Why are you doing this?

Added an option to download the CSS `@font-face` rules as a single CSS file, using Elm's [File module](https://package.elm-lang.org/packages/elm/file/latest/File).

First part of the work for #6.

cc @paperboyo 

## Changes

- Made `elm/file` a direct dependency
- Added a `Msg` to download font-face declarations as CSS file
- Updated the UI to look nicer with new download button
- Used CSS variable for `brand-400`
- Derived button styles from design system

## Screenshots

| Before | After |
| --- | --- |
![fontastique-before](https://user-images.githubusercontent.com/53781962/77755008-4e1edb00-7024-11ea-809a-3ab5350f0c8b.png) | ![fontastique-download](https://user-images.githubusercontent.com/53781962/77755010-5119cb80-7024-11ea-8503-a556fbf250d9.png)

