### PR TITLE
Use elm-format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ elm-stuff
 dist
 assets
 *.DS_Store
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ elm-stuff
 dist
 assets
 *.DS_Store
+.vscode
+!.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["elmtooling.elm-ls-vscode"]
+}

--- a/README.md
+++ b/README.md
@@ -28,3 +28,13 @@ Alternatively you can host the `dist` directory locally using a server of your c
 cd dist
 python3 -m http.server 8080
 ```
+
+## Recommended developer setup
+
+We recommend using VSCode.
+
+### Extensions
+
+VSCode should prompt you to install our recommended extensions when you open the project.
+
+You can also find these extensions by searching for `@recommended` in the extensions pane.

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,10 +49,60 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "dev": true,
+      "requires": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      }
+    },
+    "binwrap": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/binwrap/-/binwrap-0.2.2.tgz",
+      "integrity": "sha512-Y+Wvypk3JhH5GPZAvlwJAWOVH/OsOhQMSj37vySuWHwQivoALplPxfBA8b973rFJI7OS+O+1YmmYXIiEXVMAcw==",
+      "dev": true,
+      "requires": {
+        "mustache": "^3.0.1",
+        "request": "^2.88.0",
+        "request-promise": "^4.2.4",
+        "tar": "^4.4.10",
+        "unzip-stream": "^0.3.0"
+      }
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
+    },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+      "dev": true
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "dev": true,
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
+      }
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -97,6 +147,15 @@
         "request": "^2.88.0"
       }
     },
+    "elm-format": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/elm-format/-/elm-format-0.8.3.tgz",
+      "integrity": "sha512-shXOgfg8F5hDJagP91zJ3QT0PoMbusPfhgEeu3uRofTaN843cFpjZ8qlQip6pFQxtWyQE/P+NMg3vP6lyWI5Mg==",
+      "dev": true,
+      "requires": {
+        "binwrap": "^0.2.2"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -130,6 +189,15 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.6.0"
       }
     },
     "getpass": {
@@ -205,6 +273,12 @@
         "verror": "1.10.0"
       }
     },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
     "mime-db": {
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
@@ -217,6 +291,46 @@
       "requires": {
         "mime-db": "1.43.0"
       }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.9.0"
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+      "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "dev": true
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -270,6 +384,27 @@
         "uuid": "^3.3.2"
       }
     },
+    "request-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.5.tgz",
+      "integrity": "sha512-ZgnepCykFdmpq86fKGwqntyTiUrHycALuGggpyCZwMvGaZWgxW6yagT0FHkgo5LzYvOaCNvxYwWYIjevSH1EDg==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.3",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+      "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
+      }
+    },
     "safe-buffer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
@@ -296,6 +431,27 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
+    "tar": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.8.6",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
+      }
+    },
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -312,6 +468,12 @@
         }
       }
     },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+      "dev": true
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -324,6 +486,16 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "unzip-stream": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unzip-stream/-/unzip-stream-0.3.0.tgz",
+      "integrity": "sha512-NG1h/MdGIX3HzyqMjyj1laBCmlPYhcO4xEy7gEqqzGiSLw7XqDQCnY4nYSn5XSaH8mQ6TFkaujrO8d/PIZN85A==",
+      "dev": true,
+      "requires": {
+        "binary": "^0.3.0",
+        "mkdirp": "^0.5.1"
+      }
     },
     "uri-js": {
       "version": "4.2.2",
@@ -347,6 +519,12 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     },
     "dependencies": {
         "elm": "^0.19.1-3"
+    },
+    "devDependencies": {
+        "elm-format": "^0.8.3"
     }
 }

--- a/src/Cli.elm
+++ b/src/Cli.elm
@@ -1,50 +1,63 @@
 port module Cli exposing (..)
 
-import Platform
-import Json.Encode as E
-import Json.Decode as D
-
 import Font exposing (Font, fontFace, fontsDecoder)
+import Json.Decode as D
+import Json.Encode as E
+import Platform
+
 
 
 -- MAIN
 
-main = Platform.worker { init = init, update = update, subscriptions = subscriptions }
+
+main =
+    Platform.worker { init = init, update = update, subscriptions = subscriptions }
+
 
 
 -- MODEL
 
+
 type alias Model =
     Int
 
-init : D.Value -> (Model, Cmd Msg)
+
+init : D.Value -> ( Model, Cmd Msg )
 init jsonFonts =
     let
         face =
             case D.decodeValue fontsDecoder jsonFonts of
                 Ok font ->
                     String.join "\n" (List.map fontFace font)
+
                 Err message ->
                     D.errorToString message
     in
-        (0, outputFontFace <| E.string face )
+    ( 0, outputFontFace <| E.string face )
+
 
 
 -- UPDATE
 
-type Msg =
-    NoOp
+
+type Msg
+    = NoOp
+
 
 update msg model =
-    (model, Cmd.none)
+    ( model, Cmd.none )
+
 
 
 -- SUBSCRIPTIONS
+
 
 subscriptions _ =
     Sub.none
 
 
+
 -- PORTS
+
 
 port outputFontFace : E.Value -> Cmd msg

--- a/src/Font.elm
+++ b/src/Font.elm
@@ -1,20 +1,22 @@
 module Font exposing
     ( Font
     , FontFace
-    , web
     , android
     , fontFace
-    , fontsDecoder
-    , fontToString
-    , weightToString
     , fontStyleProperty
+    , fontToString
+    , fontsDecoder
+    , web
+    , weightToString
     )
 
-import Json.Decode as D exposing (Decoder)
 import Dict exposing (Dict)
+import Json.Decode as D exposing (Decoder)
+
 
 
 -- FONTS
+
 
 type Weight
     = Thin
@@ -27,27 +29,37 @@ type Weight
     | ExtraBold
     | Black
 
+
 weightToString : Weight -> String
 weightToString weight =
     case weight of
         Thin ->
             "100"
+
         ExtraLight ->
             "200"
+
         Light ->
             "300"
+
         Regular ->
             "400"
+
         Medium ->
             "500"
+
         SemiBold ->
             "600"
+
         Bold ->
             "700"
+
         ExtraBold ->
             "800"
+
         Black ->
             "900"
+
 
 type alias Font =
     { family : String
@@ -58,8 +70,10 @@ type alias Font =
     , isItalic : Bool
     }
 
+
 type alias FontFace =
     String
+
 
 fontToString : Font -> String
 fontToString { family, weight, isItalic } =
@@ -70,20 +84,25 @@ fontToString { family, weight, isItalic } =
         ++ fontStyleProperty isItalic
         ++ ")"
 
+
 type Format
     = Woff2
     | Woff
     | TTF
+
 
 formatToString : Format -> String
 formatToString format =
     case format of
         Woff2 ->
             "woff2"
+
         Woff ->
             "woff"
+
         TTF ->
             "truetype"
+
 
 groupByFamily : List Font -> List (List Font)
 groupByFamily =
@@ -92,40 +111,48 @@ groupByFamily =
             case variants of
                 Just vs ->
                     font :: vs
+
                 Nothing ->
                     List.singleton font
+
         f font =
             Dict.update font.family (Just << insertFont font)
     in
-        Dict.values << List.foldl f Dict.empty
+    Dict.values << List.foldl f Dict.empty
+
 
 
 -- WEB
 
+
 web : List Font -> List FontFace
 web =
     List.map fontFace
+
 
 fontFace : Font -> FontFace
 fontFace ({ family, weight, isItalic } as font) =
     let
         rules =
             String.join ";\n  "
-                [ fontFamily family 
+                [ fontFamily family
                 , fontWeight weight
                 , fontSrc font
                 , fontStyle isItalic
                 ]
     in
-        "@font-face {\n  " ++ rules ++ ";\n}\n"
+    "@font-face {\n  " ++ rules ++ ";\n}\n"
+
 
 fontFamily : String -> String
 fontFamily family =
     "font-family: \"" ++ family ++ "\""
 
+
 fontWeight : Weight -> String
 fontWeight weight =
     "font-weight: " ++ weightToString weight
+
 
 fontSrc : Font -> String
 fontSrc { woff2, woff, ttf } =
@@ -136,29 +163,40 @@ fontSrc { woff2, woff, ttf } =
         ++ ",\n    "
         ++ fontUrl ttf TTF
 
+
 fontUrl : String -> Format -> String
 fontUrl url format =
     "url(\"" ++ url ++ "\") " ++ fontFormat format
+
 
 fontFormat : Format -> String
 fontFormat format =
     "format(\"" ++ formatToString format ++ "\")"
 
+
 fontStyle : Bool -> String
 fontStyle isItalic =
     "font-style: " ++ fontStyleProperty isItalic
 
+
 fontStyleProperty : Bool -> String
 fontStyleProperty isItalic =
-    if isItalic then "italic" else "normal"
+    if isItalic then
+        "italic"
+
+    else
+        "normal"
+
 
 
 -- ANDROID
+
 
 android : List Font -> List FontFace
 android fonts =
     groupByFamily fonts
         |> List.map androidFamily
+
 
 androidFamily : List Font -> FontFace
 androidFamily fonts =
@@ -171,27 +209,39 @@ androidFamily fonts =
         ++ "</font-family>"
         ++ "\n"
 
+
 androidFont : Font -> String
 androidFont { weight, isItalic, ttf } =
     "    <font"
         ++ "\n        "
-        ++ "android:fontStyle=\"" ++ fontStyleProperty isItalic ++ "\""
+        ++ "android:fontStyle=\""
+        ++ fontStyleProperty isItalic
+        ++ "\""
         ++ "\n        "
-        ++ "android:fontWeight=\"" ++ weightToString weight ++ "\""
+        ++ "android:fontWeight=\""
+        ++ weightToString weight
+        ++ "\""
         ++ "\n        "
-        ++ "android:font=\"" ++ "@font/" ++ androidFilename ttf ++ "\""
+        ++ "android:font=\""
+        ++ "@font/"
+        ++ androidFilename ttf
+        ++ "\""
         ++ " />"
+
 
 androidFilename : String -> String
 androidFilename =
     String.toLower << String.replace "-" "_"
 
 
+
 -- JSON
 
+
 fontsDecoder : Decoder (List Font)
-fontsDecoder = 
+fontsDecoder =
     D.field "fonts" (D.list fontDecoder)
+
 
 fontDecoder : Decoder Font
 fontDecoder =
@@ -203,31 +253,42 @@ fontDecoder =
         (D.field "ttf" D.string)
         (D.field "isItalic" D.bool)
 
+
 weightDecoder : Decoder Weight
 weightDecoder =
     D.string
         |> D.andThen decoderWeightString
+
 
 decoderWeightString : String -> Decoder Weight
 decoderWeightString weightString =
     case weightString of
         "Thin" ->
             D.succeed Thin
+
         "ExtraLight" ->
             D.succeed ExtraLight
+
         "Light" ->
             D.succeed Light
+
         "Regular" ->
             D.succeed Regular
+
         "Medium" ->
             D.succeed Medium
+
         "Semibold" ->
             D.succeed SemiBold
+
         "Bold" ->
             D.succeed Bold
+
         "ExtraBold" ->
             D.succeed ExtraBold
+
         "Black" ->
             D.succeed Black
+
         _ ->
             D.fail ("Invalid weight: " ++ weightString)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,49 +1,65 @@
 port module Main exposing (..)
 
 import Browser
+import File.Download as Download
+import Font exposing (..)
 import Html exposing (..)
-import Html.Attributes exposing (type_, checked, style, class)
+import Html.Attributes exposing (checked, class, style, type_)
 import Html.Events exposing (onCheck, onClick)
 import Http
 import Tuple exposing (pair, second)
-import File.Download as Download
 
-import Font exposing (..)
 
 
 -- PORTS
 
+
 port sendMessage : String -> Cmd msg
+
+
 
 -- MAIN
 
-main = Browser.element
-    { init = init
-    , view = view
-    , update = update
-    , subscriptions = subscriptions
-    }
+
+main =
+    Browser.element
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = subscriptions
+        }
+
 
 
 -- MODEL
 
+
 type alias Model =
-    List (Selected, Font)
+    List ( Selected, Font )
+
 
 type alias Selected =
     Bool
 
-init : () -> (Model, Cmd Msg)
-init _ =
-    ([], getFonts)
 
-pickSelected : (Selected, Font) -> Maybe Font
-pickSelected (isSelected, font) =
-    if isSelected then Just font else Nothing
+init : () -> ( Model, Cmd Msg )
+init _ =
+    ( [], getFonts )
+
+
+pickSelected : ( Selected, Font ) -> Maybe Font
+pickSelected ( isSelected, font ) =
+    if isSelected then
+        Just font
+
+    else
+        Nothing
+
 
 selectedFonts : Model -> List Font
 selectedFonts =
     List.filterMap pickSelected
+
 
 cssString : Model -> String
 cssString model =
@@ -52,7 +68,9 @@ cssString model =
         |> String.join "\n"
 
 
+
 -- UPDATE
+
 
 type Msg
     = GotFonts (Result Http.Error (List Font))
@@ -63,48 +81,66 @@ type Msg
     | DownloadWeb
     | CopyWeb
 
-update : Msg -> Model -> (Model, Cmd Msg)
+
+update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         GotFonts result ->
             case result of
                 Ok fonts ->
-                    (List.map (pair False) fonts, Cmd.none)
+                    ( List.map (pair False) fonts, Cmd.none )
+
                 Err message ->
-                    (model, Cmd.none)
+                    ( model, Cmd.none )
+
         Check index ->
-            (List.indexedMap (setSelected index True) model, Cmd.none)
+            ( List.indexedMap (setSelected index True) model, Cmd.none )
+
         Uncheck index ->
-            (List.indexedMap (setSelected index False) model, Cmd.none)
+            ( List.indexedMap (setSelected index False) model, Cmd.none )
+
         SelectAll ->
-            (List.map (\font -> (True, second font)) model, Cmd.none)
+            ( List.map (\font -> ( True, second font )) model, Cmd.none )
+
         DeselectAll ->
-            (List.map (\font -> (False, second font)) model, Cmd.none)
+            ( List.map (\font -> ( False, second font )) model, Cmd.none )
+
         DownloadWeb ->
-            (model, Download.string "fonts.css" "text/css" (cssString model))
+            ( model, Download.string "fonts.css" "text/css" (cssString model) )
+
         CopyWeb ->
-            (model, sendMessage (cssString model))
+            ( model, sendMessage (cssString model) )
+
 
 getFonts : Cmd Msg
 getFonts =
     Http.get
-    { url = "/fonts.json"
-    , expect = Http.expectJson GotFonts fontsDecoder
-    }
+        { url = "/fonts.json"
+        , expect = Http.expectJson GotFonts fontsDecoder
+        }
 
-setSelected : Int -> Selected -> Int -> (Selected, Font) -> (Selected, Font)
+
+setSelected : Int -> Selected -> Int -> ( Selected, Font ) -> ( Selected, Font )
 setSelected selectedIndex selected index font =
-    if selectedIndex == index then (selected, second font) else font
+    if selectedIndex == index then
+        ( selected, second font )
+
+    else
+        font
+
 
 
 -- SUBSCRIPTIONS
+
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
     Sub.none
 
 
+
 -- VIEW
+
 
 view : Model -> Html Msg
 view model =
@@ -126,41 +162,45 @@ view model =
                     , onClick DeselectAll
                     ]
                     [ text "Deselect all" ]
-                , ul [ class "fields__font-list" ]
-                    <| List.indexedMap viewFont model
+                , ul [ class "fields__font-list" ] <|
+                    List.indexedMap viewFont model
                 ]
             , viewFontFaces model
             ]
         ]
+
 
 viewFontFaces : Model -> Html Msg
 viewFontFaces model =
     let
         selected =
             selectedFonts model
+
         webFonts =
             web selected
+
         androidFonts =
             android selected
     in
-        section [ class "font-faces" ]
-            [ h2 [ class "font-faces__heading" ] [ text "Get your fonts" ]
-            , hr [ class "font-faces__keyline" ] []
-            , section []
-                [ h3 [ class "font-faces__heading" ] [ text "Web" ]
-                , viewFontSource webFonts
-                , button
-                    [ class "font-faces__copy", onClick CopyWeb ]
-                    [ text "Copy CSS" ]
-                , button
-                    [ class "font-faces__download", onClick DownloadWeb ]
-                    [ text "Download CSS File" ]
-                ]
-            , section []
-                [ h3 [ class "font-faces__heading" ] [ text "Android" ]
-                , viewFontSource androidFonts
-                ]
+    section [ class "font-faces" ]
+        [ h2 [ class "font-faces__heading" ] [ text "Get your fonts" ]
+        , hr [ class "font-faces__keyline" ] []
+        , section []
+            [ h3 [ class "font-faces__heading" ] [ text "Web" ]
+            , viewFontSource webFonts
+            , button
+                [ class "font-faces__copy", onClick CopyWeb ]
+                [ text "Copy CSS" ]
+            , button
+                [ class "font-faces__download", onClick DownloadWeb ]
+                [ text "Download CSS File" ]
             ]
+        , section []
+            [ h3 [ class "font-faces__heading" ] [ text "Android" ]
+            , viewFontSource androidFonts
+            ]
+        ]
+
 
 viewFontSource : List FontFace -> Html Msg
 viewFontSource fontFaces =
@@ -174,8 +214,9 @@ viewFontSource fontFaces =
             ]
         ]
 
-viewFont : Int -> (Selected, Font) -> Html Msg
-viewFont index (selected, font) =
+
+viewFont : Int -> ( Selected, Font ) -> Html Msg
+viewFont index ( selected, font ) =
     li [ class "fields__font" ]
         [ label
             [ style "font-family" font.family
@@ -193,6 +234,11 @@ viewFont index (selected, font) =
             ]
         ]
 
+
 check : Int -> Bool -> Msg
 check index isChecked =
-    if isChecked then Check index else Uncheck index
+    if isChecked then
+        Check index
+
+    else
+        Uncheck index


### PR DESCRIPTION
## Why are you doing this?

As a new Elm developer, I would like an Elm project to have opinions to help me get straight into writing beautiful Elm code.

Globally installing and running `elm-format` as an NPM package was straightforward, but hooking it up to VSCode was a bit trickier. I ended up installing the [Elm Tooling extension](https://marketplace.visualstudio.com/items?itemName=Elmtooling.elm-ls-vscode), but I also had to install `elm-format` locally in the project to get the extension to locate the binary.

To avoid other devs hitting the same pain points as me, I've automated these steps as much as possible. Happy to hear some opinions from y'all!

Fixes #3

## Changes

- Install `elm-format` locally
- Add Elm Tooling extension to recommendations
- Run `elm-format` on existing elm files
