### PR TITLE
iOS Plist Support

### DIFF
--- a/src/Font.elm
+++ b/src/Font.elm
@@ -1,11 +1,11 @@
 module Font exposing
     ( Font
-    , FontFace
     , android
     , fontFace
     , fontStyleProperty
     , fontToString
     , fontsDecoder
+    , ios
     , web
     , weightToString
     )
@@ -71,10 +71,6 @@ type alias Font =
     }
 
 
-type alias FontFace =
-    String
-
-
 fontToString : Font -> String
 fontToString { family, weight, isItalic } =
     family
@@ -125,12 +121,13 @@ groupByFamily =
 -- WEB
 
 
-web : List Font -> List FontFace
+web : List Font -> String
 web =
     List.map fontFace
+        >> String.join "\n"
 
 
-fontFace : Font -> FontFace
+fontFace : Font -> String
 fontFace ({ family, weight, isItalic } as font) =
     let
         rules =
@@ -192,13 +189,14 @@ fontStyleProperty isItalic =
 -- ANDROID
 
 
-android : List Font -> List FontFace
+android : List Font -> String
 android fonts =
     groupByFamily fonts
         |> List.map androidFamily
+        |> String.join "\n"
 
 
-androidFamily : List Font -> FontFace
+androidFamily : List Font -> String
 androidFamily fonts =
     "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
         ++ "\n"
@@ -232,6 +230,26 @@ androidFont { weight, isItalic, ttf } =
 androidFilename : String -> String
 androidFilename =
     String.toLower << String.replace "-" "_"
+
+
+
+-- iOS
+
+
+ios : List Font -> String
+ios fonts =
+    "<key>UIAppFonts</key>"
+        ++ "\n"
+        ++ "<array>"
+        ++ "\n"
+        ++ String.join "\n" (List.map iosFont fonts)
+        ++ "\n"
+        ++ "</array>"
+
+
+iosFont : Font -> String
+iosFont font =
+    "    <string>" ++ font.ttf ++ "</string>"
 
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -182,28 +182,28 @@ viewFontFaces model =
         iosFonts =
             ios selected
     in
-        section [ class "font-faces" ]
-            [ h2 [ class "font-faces__heading" ] [ text "Get your fonts" ]
-            , hr [ class "font-faces__keyline" ] []
-            , section []
-                [ h3 [ class "font-faces__heading" ] [ text "Web" ]
-                , viewFontSource webFonts
-                , button
-                    [ class "font-faces__copy", onClick CopyWeb ]
-                    [ text "Copy CSS" ]
-                , button
-                    [ class "font-faces__download", onClick DownloadWeb ]
-                    [ text "Download CSS File" ]
-                ]
-            , section []
-                [ h3 [ class "font-faces__heading" ] [ text "Android" ]
-                , viewFontSource androidFonts
-                ]
-            , section []
-                [ h3 [ class "font-faces__heading" ] [ text "iOS" ]
-                , viewFontSource iosFonts
-                ]
+    section [ class "font-faces" ]
+        [ h2 [ class "font-faces__heading" ] [ text "Get your fonts" ]
+        , hr [ class "font-faces__keyline" ] []
+        , section []
+            [ h3 [ class "font-faces__heading" ] [ text "Web" ]
+            , viewFontSource webFonts
+            , button
+                [ class "font-faces__copy", onClick CopyWeb ]
+                [ text "Copy CSS" ]
+            , button
+                [ class "font-faces__download", onClick DownloadWeb ]
+                [ text "Download CSS File" ]
             ]
+        , section []
+            [ h3 [ class "font-faces__heading" ] [ text "Android" ]
+            , viewFontSource androidFonts
+            ]
+        , section []
+            [ h3 [ class "font-faces__heading" ] [ text "iOS" ]
+            , viewFontSource iosFonts
+            ]
+        ]
 
 
 viewFontSource : String -> Html Msg

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -62,10 +62,8 @@ selectedFonts =
 
 
 cssString : Model -> String
-cssString model =
-    selectedFonts model
-        |> web
-        |> String.join "\n"
+cssString =
+    selectedFonts >> web
 
 
 
@@ -181,36 +179,40 @@ viewFontFaces model =
 
         androidFonts =
             android selected
+        iosFonts =
+            ios selected
     in
-    section [ class "font-faces" ]
-        [ h2 [ class "font-faces__heading" ] [ text "Get your fonts" ]
-        , hr [ class "font-faces__keyline" ] []
-        , section []
-            [ h3 [ class "font-faces__heading" ] [ text "Web" ]
-            , viewFontSource webFonts
-            , button
-                [ class "font-faces__copy", onClick CopyWeb ]
-                [ text "Copy CSS" ]
-            , button
-                [ class "font-faces__download", onClick DownloadWeb ]
-                [ text "Download CSS File" ]
+        section [ class "font-faces" ]
+            [ h2 [ class "font-faces__heading" ] [ text "Get your fonts" ]
+            , hr [ class "font-faces__keyline" ] []
+            , section []
+                [ h3 [ class "font-faces__heading" ] [ text "Web" ]
+                , viewFontSource webFonts
+                , button
+                    [ class "font-faces__copy", onClick CopyWeb ]
+                    [ text "Copy CSS" ]
+                , button
+                    [ class "font-faces__download", onClick DownloadWeb ]
+                    [ text "Download CSS File" ]
+                ]
+            , section []
+                [ h3 [ class "font-faces__heading" ] [ text "Android" ]
+                , viewFontSource androidFonts
+                ]
+            , section []
+                [ h3 [ class "font-faces__heading" ] [ text "iOS" ]
+                , viewFontSource iosFonts
+                ]
             ]
-        , section []
-            [ h3 [ class "font-faces__heading" ] [ text "Android" ]
-            , viewFontSource androidFonts
-            ]
-        ]
 
 
-viewFontSource : List FontFace -> Html Msg
+viewFontSource : String -> Html Msg
 viewFontSource fontFaces =
     details []
         [ summary [ class "font-faces__source" ] [ text "View Source" ]
         , pre
             [ class "font-faces__code" ]
-            [ fontFaces
-                |> String.join "\n"
-                |> text
+            [ text fontFaces
             ]
         ]
 


### PR DESCRIPTION
## Why are you doing this?

Adding a way to generate the chunk of `Info.plist` needed to include [custom fonts](https://developer.apple.com/documentation/uikit/text_display_and_fonts/adding_a_custom_font_to_your_app) in an iOS app. Part of #5.

## Changes

- Added functions to `Font.elm` to generate plist string
- Added new section to UI for iOS fonts
- Removed `FontFace` type alias

## Screenshots

![ios-fontastique](https://user-images.githubusercontent.com/53781962/78779211-77305b80-7994-11ea-91f8-55ef1619d112.png)
