### PR TITLE
Typography Advice

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -4,7 +4,7 @@ import Browser
 import File.Download as Download
 import Font exposing (..)
 import Html exposing (..)
-import Html.Attributes exposing (checked, class, style, type_)
+import Html.Attributes exposing (checked, class, style, type_, href)
 import Html.Events exposing (onCheck, onClick)
 import Http
 import Tuple exposing (pair, second)
@@ -150,6 +150,7 @@ view model =
             [ fieldset [ class "fields" ]
                 [ h2 [ class "fields__heading" ] [ text "Choose your fonts" ]
                 , hr [ class "fields__keyline" ] []
+                , viewTypographyAdvice
                 , button
                     [ class "fields__button"
                     , onClick SelectAll
@@ -164,6 +165,21 @@ view model =
                     List.indexedMap viewFont model
                 ]
             , viewFontFaces model
+            ]
+        ]
+
+
+viewTypographyAdvice : Html Msg
+viewTypographyAdvice =
+    aside [ class "fields__advice" ]
+        [ p []
+            [ text "For more information about the font faces and their recommended use in designs, please see "
+            , a
+                [ class "fields__anchor"
+                , href "https://www.theguardian.design/2a1e5182b/p/930d69-typography/b/78d0d9"
+                ]
+                [ text "the Typography section " ]
+            , text "of the design system docs."
             ]
         ]
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -178,8 +178,8 @@ viewTypographyAdvice =
                 [ class "fields__anchor"
                 , href "https://www.theguardian.design/2a1e5182b/p/930d69-typography/b/78d0d9"
                 ]
-                [ text "the Typography section " ]
-            , text "of the design system docs."
+                [ text "the Typography section" ]
+            , text " of the design system docs."
             ]
         ]
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -193,6 +193,15 @@ body {
   border-right: 1px solid #dcdcdc;
 }
 
+.fields__advice {
+  font-family: "Guardian Text Egyptian";
+  font-style: italic;
+}
+
+.fields__anchor {
+  color: var(--brand-400);
+}
+
 .fields__heading, .font-faces__heading {
   margin: 0;
   font-family: "Guardian Headline";


### PR DESCRIPTION
## Why are you doing this?

Adds a link to the Typography section of the design system docs, along with advice to look there for design recommendations. Fixes #7.

## Changes

- Added an `<aside>` with Typography advice and link to design system

## Screenshots

<img width="386" alt="typography" src="https://user-images.githubusercontent.com/53781962/83661359-e81f7880-a5bd-11ea-89dc-31bfc955db34.png">
